### PR TITLE
Fix typo in EnterpriseContractPolicyConifguration

### DIFF
--- a/api/v1alpha1/enterprisecontractpolicy_types.go
+++ b/api/v1alpha1/enterprisecontractpolicy_types.go
@@ -108,7 +108,7 @@ type EnterpriseContractPolicyConfiguration struct {
 	// Collections set of predefined rules.
 	// +optional
 	// +listType:=set
-	Collections []string `json:"collections;omitempty"`
+	Collections []string `json:"collections,omitempty"`
 }
 
 // EnterpriseContractPolicyStatus defines the observed state of EnterpriseContractPolicy

--- a/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -66,7 +66,7 @@ spec:
                 description: Configuration handles policy modification configuration
                   (collections, exclusions, inclusions)
                 properties:
-                  collections;omitempty:
+                  collections:
                     description: Collections set of predefined rules.
                     items:
                       type: string

--- a/docs/modules/ROOT/pages/reference.adoc
+++ b/docs/modules/ROOT/pages/reference.adoc
@@ -85,7 +85,7 @@ Appears In: xref:{anchor_prefix}-github-com-hacbs-contract-enterprise-contract-c
 | Field | Description
 | *`excludeRules`* __string array__ | ExcludeRules set of policy exclusions that, in case of failure, do not block the success of the outcome.
 | *`includeRules`* __string array__ | IncludeRules set of policy inclusions that are added to the policy evaluation. These override excluded rules.
-| *`collections;omitempty`* __string array__ | Collections set of predefined rules.
+| *`collections`* __string array__ | Collections set of predefined rules.
 |===
 
 


### PR DESCRIPTION
An errant semicolon was found.

Signed-off-by: Rob Nester <rnester@redhat.com>