### PR TITLE
Add IgnoreRekor attribute to ECP

### DIFF
--- a/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -92,11 +92,14 @@ spec:
                       description: SubjectRegExp is a regular expression to match the URL of the certificate identity for keyless verification.
                       type: string
                   type: object
+                ignoreRekor:
+                  description: Whether or not to skip Rekor during verification
+                  type: boolean
                 publicKey:
                   description: Public key used to validate the signature of images and attestations
                   type: string
                 rekorUrl:
-                  description: URL of the Rekor instance. Empty string disables Rekor integration
+                  description: URL of the Rekor instance
                   type: string
                 sources:
                   description: One or more groups of policy rules

--- a/api/v1alpha1/enterprisecontractpolicy_types.go
+++ b/api/v1alpha1/enterprisecontractpolicy_types.go
@@ -38,9 +38,12 @@ type EnterpriseContractPolicySpec struct {
 	// Configuration handles policy modification configuration (exclusions and inclusions)
 	// +optional
 	Configuration *EnterpriseContractPolicyConfiguration `json:"configuration,omitempty"`
-	// URL of the Rekor instance. Empty string disables Rekor integration
+	// URL of the Rekor instance
 	// +optional
 	RekorUrl string `json:"rekorUrl,omitempty"`
+	// Whether or not to skip Rekor during verification
+	// +optional
+	IgnoreRekor bool `json:"ignoreRekor,omitempty"`
 	// Public key used to validate the signature of images and attestations
 	// +optional
 	PublicKey string `json:"publicKey,omitempty"`

--- a/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -92,11 +92,14 @@ spec:
                       description: SubjectRegExp is a regular expression to match the URL of the certificate identity for keyless verification.
                       type: string
                   type: object
+                ignoreRekor:
+                  description: Whether or not to skip Rekor during verification
+                  type: boolean
                 publicKey:
                   description: Public key used to validate the signature of images and attestations
                   type: string
                 rekorUrl:
-                  description: URL of the Rekor instance. Empty string disables Rekor integration
+                  description: URL of the Rekor instance
                   type: string
                 sources:
                   description: One or more groups of policy rules


### PR DESCRIPTION
https://issues.redhat.com/browse/HACBS-2165

Let's be explicit about when to skip Rekor during validation. The RekorUrl parameter is not always required to enforce Rekor verification. For example, if a signature contains a bundle with SignedEntryTimestamp[0], then the RekorURL is skipped in favor of the Rekor public keys loaded via TUF. For those use cases, leaving the RekorUrl empty, but still expect Rekor to be part of the verification, is in fact the right thing to do.

[0] https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md