### PR TITLE
Make sure the "all" category is set

### DIFF
--- a/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   group: appstudio.redhat.com
   names:
+    categories:
+      - all
     kind: EnterpriseContractPolicy
     listKind: EnterpriseContractPolicyList
     plural: enterprisecontractpolicies

--- a/api/v1alpha1/enterprisecontractpolicy_types.go
+++ b/api/v1alpha1/enterprisecontractpolicy_types.go
@@ -109,8 +109,7 @@ type EnterpriseContractPolicyStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all
-// +kubebuilder:resource:shortName=ecp
+// +kubebuilder:resource:categories={all},shortName={ecp}
 // +kubebuilder:subresource:status
 // EnterpriseContractPolicy is the Schema for the enterprisecontractpolicies API
 type EnterpriseContractPolicy struct {

--- a/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   group: appstudio.redhat.com
   names:
+    categories:
+      - all
     kind: EnterpriseContractPolicy
     listKind: EnterpriseContractPolicyList
     plural: enterprisecontractpolicies


### PR DESCRIPTION
What we had did not work with the `controller-gen` tool, we need the ECP in the `all` category so `kubectl get all` shows it.