### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,63 @@
+---
+name: Release
+
+"on":
+  workflow_run:
+    workflows: [Checks]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  info:
+    name: Info
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.head_sha.outputs.head_sha }}
+      timestamp: ${{ steps.timestamp.outputs.timestamp }}
+
+    steps:
+      - name: Git Info
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_COBRA: 1
+        run: |
+          echo head_sha=$(gh api /repos/enterprise-contract/enterprise-contract-controller/git/matching-refs/heads/main --jq '.[0].object.sha') >> "$GITHUB_OUTPUT"
+
+  release:
+
+    permissions:
+      contents: write  # for Git to git tag push and release
+    name: Release
+    runs-on: ubuntu-latest
+    needs: info
+    if: ${{ (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha == needs.info.outputs.head_sha) || github.event.workflow_dispatch }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          set -o errexit
+          set -o pipefail
+          set -o nounset
+
+          latest=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo 0.1.0)
+          echo "version="${latest%.*}".$(git rev-list --count "${latest}"..HEAD || echo 0)" >> "$GITHUB_ENV"
+
+      - name: Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        with:
+          name: Rolling release
+          body: Release ${{env.version}}
+          tag_name: ${{env.version}}
+          generate_release_notes: true


### PR DESCRIPTION
The main purpose of this is to create a tag so that releases are picked up by DependaBot. Versions are computed as:

    0.1.<number of commits in the repository>

Or continue from the latest tag's `major.minor` version.

Resolves #217