### PR TITLE
Include schema in api/v1alpha package and allow any property in `ruleData`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -51,6 +51,14 @@ jobs:
           files: ./api_cover.out
           flags: api
 
+      - name: Upload schema test coverage report
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./schema_cover.out
+          flags: schema
+
       # If enterprisecontractpolicy_types.go is updated without a corresponding change to the crd
       # an uncommitted change can show.
       - name: Check for uncommitted changes

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 	cd api && go test ./... -coverprofile ../api_cover.out
+	cd schema && go test ./... -coverprofile ../schema_cover.out
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ manifests: api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml ## Ge
 .PHONY: generate
 generate: $(GEN_DEPS) ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths=./...
+	cd api && go generate ./...
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -107,8 +108,9 @@ docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
 .PHONY: export-schema
-export-schema: ## Export the CRD schema to the schema directory as a json-store.org schema.
-	go run -modfile $(ROOT)schema/go.mod schema/export.go $(ROOT)dist github.com/enterprise-contract/enterprise-contract-controller ./api/v1alpha1/
+export-schema: generate ## Export the CRD schema to the schema directory as a json-store.org schema.
+	cp api/v1alpha1/policy_spec.json dist/
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,8 +1,6 @@
 module github.com/enterprise-contract/enterprise-contract-controller/api
 
-go 1.21
-
-toolchain go1.21.1
+go 1.21.4
 
 require (
 	k8s.io/apiextensions-apiserver v0.29.2

--- a/api/v1alpha1/policy_spec.json
+++ b/api/v1alpha1/policy_spec.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1/enterprise-contract-policy-spec",
+  "$ref": "#/$defs/EnterpriseContractPolicySpec",
+  "$defs": {
+    "EnterpriseContractPolicyConfiguration": {
+      "properties": {
+        "exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Exclude set of policy exclusions that, in case of failure, do not block\nthe success of the outcome.\n+optional\n+listType:=set"
+        },
+        "include": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Include set of policy inclusions that are added to the policy evaluation.\nThese override excluded rules.\n+optional\n+listType:=set"
+        },
+        "collections": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Collections set of predefined rules.  DEPRECATED: Collections can be listed in include\nwith the \"@\" prefix.\n+optional\n+listType:=set"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "EnterpriseContractPolicyConfiguration configuration of modifications to policy evaluation."
+    },
+    "EnterpriseContractPolicySpec": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Optional name of the policy\n+optional"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the policy or its intended use\n+optional"
+        },
+        "sources": {
+          "items": {
+            "$ref": "#/$defs/Source"
+          },
+          "type": "array",
+          "description": "One or more groups of policy rules\n+kubebuilder:validation:MinItems:=1"
+        },
+        "configuration": {
+          "$ref": "#/$defs/EnterpriseContractPolicyConfiguration",
+          "description": "Configuration handles policy modification configuration (exclusions and inclusions)\n+optional"
+        },
+        "rekorUrl": {
+          "type": "string",
+          "description": "URL of the Rekor instance. Empty string disables Rekor integration\n+optional"
+        },
+        "publicKey": {
+          "type": "string",
+          "description": "Public key used to validate the signature of images and attestations\n+optional"
+        },
+        "identity": {
+          "$ref": "#/$defs/Identity",
+          "description": "Identity to be used for keyless verification. This is an experimental feature.\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "EnterpriseContractPolicySpec is used to configure the Enterprise Contract Policy"
+    },
+    "Identity": {
+      "properties": {
+        "subject": {
+          "type": "string",
+          "description": "Subject is the URL of the certificate identity for keyless verification.\n+optional"
+        },
+        "subjectRegExp": {
+          "type": "string",
+          "description": "SubjectRegExp is a regular expression to match the URL of the certificate identity for\nkeyless verification.\n+optional"
+        },
+        "issuer": {
+          "type": "string",
+          "description": "Issuer is the URL of the certificate OIDC issuer for keyless verification.\n+optional"
+        },
+        "issuerRegExp": {
+          "type": "string",
+          "description": "IssuerRegExp is a regular expression to match the URL of the certificate OIDC issuer for\nkeyless verification.\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Identity defines the allowed identity for keyless signing."
+    },
+    "JSON": {
+      "properties": {},
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "Source": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Optional name for the source\n+optional"
+        },
+        "policy": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "List of go-getter style policy source urls\n+kubebuilder:validation:MinItems:=1"
+        },
+        "data": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "List of go-getter style policy data source urls\n+optional"
+        },
+        "ruleData": {
+          "$ref": "#/$defs/JSON",
+          "description": "Arbitrary rule data that will be visible to policy rules\n+optional\n+kubebuilder:validation:Type:=object"
+        },
+        "config": {
+          "$ref": "#/$defs/SourceConfig",
+          "description": "Config specifies which policy rules are included, or excluded, from the\nprovided policy source urls.\n+optional\n+kubebuilder:validation:Type:=object"
+        },
+        "volatileConfig": {
+          "$ref": "#/$defs/VolatileSourceConfig",
+          "description": "Specifies volatile configuration that can include or exclude policy rules\nbased on effective time.\n+optional\n+kubebuilder:validation:Type:=object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Source defines policies and data that are evaluated together"
+    },
+    "SourceConfig": {
+      "properties": {
+        "exclude": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Exclude is a set of policy exclusions that, in case of failure, do not block\nthe success of the outcome.\n+optional\n+listType:=set"
+        },
+        "include": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Include is a set of policy inclusions that are added to the policy evaluation.\nThese take precedence over policy exclusions.\n+optional\n+listType:=set"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SourceConfig specifies config options for a policy source."
+    },
+    "VolatileCriteria": {
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "effectiveOn": {
+          "type": "string",
+          "description": "+optional\n+kubebuilder:validation:Format:=date-time"
+        },
+        "effectiveUntil": {
+          "type": "string",
+          "description": "+optional\n+kubebuilder:validation:Format:=date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "value"
+      ],
+      "description": "VolatileCriteria includes or excludes a policy rule with effective dates as an option."
+    },
+    "VolatileSourceConfig": {
+      "properties": {
+        "exclude": {
+          "items": {
+            "$ref": "#/$defs/VolatileCriteria"
+          },
+          "type": "array",
+          "description": "Exclude is a set of policy exclusions that, in case of failure, do not block\nthe success of the outcome.\n+optional\n+listType:=map\n+listMapKey:=value"
+        },
+        "include": {
+          "items": {
+            "$ref": "#/$defs/VolatileCriteria"
+          },
+          "type": "array",
+          "description": "Include is a set of policy inclusions that are added to the policy evaluation.\nThese take precedence over policy exclusions.\n+optional\n+listType:=map\n+listMapKey:=value"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "VolatileSourceConfig specifies volatile configuration for a policy source."
+    }
+  }
+}

--- a/api/v1alpha1/schema.go
+++ b/api/v1alpha1/schema.go
@@ -1,0 +1,7 @@
+package v1alpha1
+
+import _ "embed"
+
+//go:generate go run -modfile ../../schema/go.mod ../../schema/export.go . github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1 .
+//go:embed policy_spec.json
+var Schema string

--- a/schema/export_test.go
+++ b/schema/export_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1alpha1 "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestJsonAdditionalProperties(t *testing.T) {
+	schema, err := jsonschema.CompileString("schema.json", v1alpha1.Schema)
+	if err != nil {
+		t.Errorf("unable to compile the schema for v1alpha1: %v", err)
+	}
+
+	ruleData := []byte(`{"any": "value"}`)
+
+	policy := v1alpha1.EnterpriseContractPolicySpec{
+		Sources: []v1alpha1.Source{
+			{
+				RuleData: &v1.JSON{
+					Raw: ruleData,
+				},
+			},
+		},
+	}
+
+	j, err := json.Marshal(policy)
+	if err != nil {
+		t.Errorf("unable to marshal policy to JSON: %v", err)
+	}
+
+	val := map[string]any{}
+	if err := json.Unmarshal(j, &val); err != nil {
+		t.Errorf("unable to unmarshal JSON: %v", err)
+	}
+
+	if err := schema.Validate(val); err != nil {
+		t.Errorf("schema validation should pass, but it failed with: %v", err)
+	}
+}

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/afero v1.11.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	golang.org/x/net v0.21.0 // indirect
@@ -32,3 +33,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace github.com/enterprise-contract/enterprise-contract-controller/api => ../api

--- a/schema/go.sum
+++ b/schema/go.sum
@@ -47,6 +47,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
Makes the schema available in via the `Schema` variable in the `api/v1alpha` package by running the schema generator and embedding it in `schema.go`.

Sets `additionalProperties: true` to the `JSON` type definition, used in the `ruleData` key.