### PR TITLE
We need to use go 1.21

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,8 @@
 module github.com/enterprise-contract/enterprise-contract-controller/api
 
-go 1.21.4
+go 1.21
+
+toolchain go1.21.2
 
 require (
 	k8s.io/apiextensions-apiserver v0.29.3

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/enterprise-contract-controller/schema
 
-go 1.21.4
+go 1.21
 
 require (
 	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.35


### PR DESCRIPTION
The release service builds with 1.21 and can't upgrade to newer version.