### PR TITLE
Use source.config instead of configuration

### DIFF
--- a/docs/modules/ROOT/examples/k8s-example.yaml
+++ b/docs/modules/ROOT/examples/k8s-example.yaml
@@ -5,10 +5,6 @@ metadata:
   name: ec-policy
   namespace: acme
 spec:
-  configuration:
-    exclude:
-    - friday_policy
-    - room_temperature
   description: ACME & co policy
   sources:
   - data:
@@ -16,4 +12,8 @@ spec:
     name: simple
     policy:
     - git::https://github.com/acme/ec-policy.git//policy?ref=prod
+    config:
+      exclude:
+      - friday_policy
+      - room_temperature
 status: {}

--- a/docs/modules/ROOT/examples/spec-example.json
+++ b/docs/modules/ROOT/examples/spec-example.json
@@ -8,13 +8,13 @@
       ],
       "data": [
         "git::https://github.com/acme/ec-policy.git//data?ref=prod"
-      ]
+      ],
+      "config": {
+        "exclude": [
+          "friday_policy",
+          "room_temperature"
+        ]
+      }
     }
-  ],
-  "configuration": {
-    "exclude": [
-      "friday_policy",
-      "room_temperature"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
The "global" `configuration` is deprecated. Instead, the `config` attribute for a certain policy source should be used.

Ref: EC-688