### PR TITLE
Golang version fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.21@sha256:2ff79bcdaff74368a9fdcb06f6599e54a71caf520fd2357a55feddd504bcaffb as builder
+FROM docker.io/library/golang:1.22.7 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterprise-contract/enterprise-contract-controller/api
 
-go 1.22
+go 1.22 // allow
 
 require (
 	k8s.io/apiextensions-apiserver v0.29.9


### PR DESCRIPTION
The `Dockerfile` is mostly unused, but the version will be flagged as incompatible if not set to 1.22.7.

Also, allows the version to be not as specific as required by the version check[1]

[1] https://github.com/enterprise-contract/github-workflows/tree/main/golang-version-check