### PR TITLE
Mention the new project name in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Enterprise Contract welcomes contributions in many forms. [Pull requests](https://docs.github.com/en/get-started/quickstart/github-glossary#pull-request) are specifically appreciated and the maintainers will make every effort to assist with any issues in the pull request discussion. Feel free to create a pull request even if you are new to the process. If you need more information, see [this article](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) about how creating a pull request.
+Conforma (formerly known as Enterprise Contract) welcomes contributions in many forms. [Pull requests](https://docs.github.com/en/get-started/quickstart/github-glossary#pull-request) are specifically appreciated and the maintainers will make every effort to assist with any issues in the pull request discussion. Feel free to create a pull request even if you are new to the process. If you need more information, see [this article](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) about how creating a pull request.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Enterprise Contract controller
-A Kubernetes controller for Enterprise Contract resources.
+
+A Kubernetes controller that defines a CRD for Conforma (formerly known as Enterprise Contract) resources.
 
 ## Description
 Currently contains `EnterpriseContractConfiguration` Kubernetes custom resource. See an [example](config/samples/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy.yaml).
+
+> [!NOTE]
+> Enterprise Contract is now called Conforma. However, because changing the CRD and controller name would have a large impact, we're not going to rename them at this stage.
 
 ## Getting Started
 You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,4 +1,13 @@
-= About Enterprise Contract Policy
+= About Conforma Policy
+
+NOTE: Conforma was previously known as "Enterprise Contract". In general you
+can consider "Conforma" and "Enterprise Contract" to be synonynous. See
+link:/posts/whats-in-a-name/[this article] for more details about the name
+change. However, because renaming the CRD and the controller is a large and
+significant change that impacts multiple other systems, the controller and the
+CRD are going to keep their original names, at least in the short and medium
+term. As a consequence this documentation will continue to refer to "Enterprise
+Contract" in many places.
 
 The Enterprise Contract Policy defines the configuration for the enforcement of the Enterprise
 Contract by specifying the rules needed for a container image to be compliant with an organization's


### PR DESCRIPTION
As stated in the docs, we won't rename the CRD yet. (Actually we're planning to move it to the ec-cli and sunset this controller, so that's the long-term plan for this repo.)

Ref: https://issues.redhat.com/browse/EC-1073