### PR TITLE
Deprecate ImageRef

### DIFF
--- a/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -165,8 +165,14 @@ spec:
                                 effectiveUntil:
                                   format: date-time
                                   type: string
+                                imageDigest:
+                                  description: ImageDigest is used to specify an image by its digest.
+                                  pattern: ^sha256:[a-fA-F0-9]{64}$
+                                  type: string
                                 imageRef:
-                                  description: ImageRef is used to specify an image by its digest.
+                                  description: |-
+                                    DEPRECATED: Use ImageDigest instead
+                                    ImageRef is used to specify an image by its digest.
                                   pattern: ^sha256:[a-fA-F0-9]{64}$
                                   type: string
                                 imageUrl:
@@ -192,8 +198,14 @@ spec:
                                 effectiveUntil:
                                   format: date-time
                                   type: string
+                                imageDigest:
+                                  description: ImageDigest is used to specify an image by its digest.
+                                  pattern: ^sha256:[a-fA-F0-9]{64}$
+                                  type: string
                                 imageRef:
-                                  description: ImageRef is used to specify an image by its digest.
+                                  description: |-
+                                    DEPRECATED: Use ImageDigest instead
+                                    ImageRef is used to specify an image by its digest.
                                   pattern: ^sha256:[a-fA-F0-9]{64}$
                                   type: string
                                 imageUrl:

--- a/api/v1alpha1/enterprisecontractpolicy_types.go
+++ b/api/v1alpha1/enterprisecontractpolicy_types.go
@@ -100,10 +100,16 @@ type VolatileCriteria struct {
 	// +kubebuilder:validation:Format:=date-time
 	EffectiveUntil string `json:"effectiveUntil,omitempty"`
 
+	// DEPRECATED: Use ImageDigest instead
 	// ImageRef is used to specify an image by its digest.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^sha256:[a-fA-F0-9]{64}$`
 	ImageRef string `json:"imageRef,omitempty"`
+
+	// ImageDigest is used to specify an image by its digest.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^sha256:[a-fA-F0-9]{64}$`
+	ImageDigest string `json:"imageDigest,omitempty"`
 
 	// ImageUrl is used to specify an image by its URL with or without a tag.
 	// +optional

--- a/api/v1alpha1/policy_spec.json
+++ b/api/v1alpha1/policy_spec.json
@@ -170,7 +170,11 @@
         },
         "imageRef": {
           "type": "string",
-          "description": "ImageRef is used to specify an image by its digest.\n+optional\n+kubebuilder:validation:Pattern=`^sha256:[a-fA-F0-9]{64}$`"
+          "description": "DEPRECATED: Use ImageDigest instead\nImageRef is used to specify an image by its digest.\n+optional\n+kubebuilder:validation:Pattern=`^sha256:[a-fA-F0-9]{64}$`"
+        },
+        "imageDigest": {
+          "type": "string",
+          "description": "ImageDigest is used to specify an image by its digest.\n+optional\n+kubebuilder:validation:Pattern=`^sha256:[a-fA-F0-9]{64}$`"
         },
         "imageUrl": {
           "type": "string",

--- a/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -165,8 +165,14 @@ spec:
                                 effectiveUntil:
                                   format: date-time
                                   type: string
+                                imageDigest:
+                                  description: ImageDigest is used to specify an image by its digest.
+                                  pattern: ^sha256:[a-fA-F0-9]{64}$
+                                  type: string
                                 imageRef:
-                                  description: ImageRef is used to specify an image by its digest.
+                                  description: |-
+                                    DEPRECATED: Use ImageDigest instead
+                                    ImageRef is used to specify an image by its digest.
                                   pattern: ^sha256:[a-fA-F0-9]{64}$
                                   type: string
                                 imageUrl:
@@ -192,8 +198,14 @@ spec:
                                 effectiveUntil:
                                   format: date-time
                                   type: string
+                                imageDigest:
+                                  description: ImageDigest is used to specify an image by its digest.
+                                  pattern: ^sha256:[a-fA-F0-9]{64}$
+                                  type: string
                                 imageRef:
-                                  description: ImageRef is used to specify an image by its digest.
+                                  description: |-
+                                    DEPRECATED: Use ImageDigest instead
+                                    ImageRef is used to specify an image by its digest.
                                   pattern: ^sha256:[a-fA-F0-9]{64}$
                                   type: string
                                 imageUrl:


### PR DESCRIPTION
The name is confusing since the value is only the image digest, so renaming to ImageDigest.