### PR TITLE
Remove optional tag from imageUrl

### DIFF
--- a/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -176,8 +176,8 @@ spec:
                                   pattern: ^sha256:[a-fA-F0-9]{64}$
                                   type: string
                                 imageUrl:
-                                  description: ImageUrl is used to specify an image by its URL with or without a tag.
-                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+(?::[a-zA-Z0-9._-]+)?$
+                                  description: ImageUrl is used to specify an image by its URL without a tag.
+                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$
                                   type: string
                                 value:
                                   type: string
@@ -209,8 +209,8 @@ spec:
                                   pattern: ^sha256:[a-fA-F0-9]{64}$
                                   type: string
                                 imageUrl:
-                                  description: ImageUrl is used to specify an image by its URL with or without a tag.
-                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+(?::[a-zA-Z0-9._-]+)?$
+                                  description: ImageUrl is used to specify an image by its URL without a tag.
+                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$
                                   type: string
                                 value:
                                   type: string

--- a/api/v1alpha1/enterprisecontractpolicy_types.go
+++ b/api/v1alpha1/enterprisecontractpolicy_types.go
@@ -111,9 +111,9 @@ type VolatileCriteria struct {
 	// +kubebuilder:validation:Pattern=`^sha256:[a-fA-F0-9]{64}$`
 	ImageDigest string `json:"imageDigest,omitempty"`
 
-	// ImageUrl is used to specify an image by its URL with or without a tag.
+	// ImageUrl is used to specify an image by its URL without a tag.
 	// +optional
-	// +kubebuilder:validation:Pattern=`^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+(?::[a-zA-Z0-9._-]+)?$`
+	// +kubebuilder:validation:Pattern=`^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$`
 	ImageUrl string `json:"imageUrl,omitempty"`
 }
 

--- a/api/v1alpha1/policy_spec.json
+++ b/api/v1alpha1/policy_spec.json
@@ -178,7 +178,7 @@
         },
         "imageUrl": {
           "type": "string",
-          "description": "ImageUrl is used to specify an image by its URL with or without a tag.\n+optional\n+kubebuilder:validation:Pattern=`^(?:https:\\/\\/)?[a-z0-9.-]+\\/[a-z0-9-]+\\/[a-z0-9-]+(?::[a-zA-Z0-9._-]+)?$`"
+          "description": "ImageUrl is used to specify an image by its URL without a tag.\n+optional\n+kubebuilder:validation:Pattern=`^(?:https:\\/\\/)?[a-z0-9.-]+\\/[a-z0-9-]+\\/[a-z0-9-]+$`"
         }
       },
       "additionalProperties": false,

--- a/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -176,8 +176,8 @@ spec:
                                   pattern: ^sha256:[a-fA-F0-9]{64}$
                                   type: string
                                 imageUrl:
-                                  description: ImageUrl is used to specify an image by its URL with or without a tag.
-                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+(?::[a-zA-Z0-9._-]+)?$
+                                  description: ImageUrl is used to specify an image by its URL without a tag.
+                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$
                                   type: string
                                 value:
                                   type: string
@@ -209,8 +209,8 @@ spec:
                                   pattern: ^sha256:[a-fA-F0-9]{64}$
                                   type: string
                                 imageUrl:
-                                  description: ImageUrl is used to specify an image by its URL with or without a tag.
-                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+(?::[a-zA-Z0-9._-]+)?$
+                                  description: ImageUrl is used to specify an image by its URL without a tag.
+                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$
                                   type: string
                                 value:
                                   type: string


### PR DESCRIPTION
The url is supposed to reflect a component. Removing the optional tag better reflects this.