### PR TITLE
Rename Enterprise Contract to Conforma in ECC

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,4 +1,4 @@
-# Copyright The Enterprise Contract Contributors
+# Copyright The Conforma Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -16,7 +16,7 @@
 
 ---
 name: ecc
-title: Enterprise Contract Configuration
+title: Conforma Configuration
 version: ~
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,2 +1,2 @@
-* xref:index.adoc[About Enterprise Contract Configuration]
+* xref:index.adoc[About Conforma Configuration]
 * xref:reference.adoc[Reference]

--- a/hack/next-version.sh
+++ b/hack/next-version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright The Enterprise Contract Contributors
+# Copyright The Conforma Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR renames "Enterprise Contract" to "Conforma" except where it's used to refer to the CRD.

resolves: EC-1129