### PR TITLE
Ensure dist dir exists when exporting schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ docker-push: ## Push docker image with the manager.
 
 .PHONY: export-schema
 export-schema: generate ## Export the CRD schema to the schema directory as a json-store.org schema.
+	@mkdir -p dist
 	cp api/v1alpha1/policy_spec.json dist/
 
 ##@ Deployment


### PR DESCRIPTION
Should fix an error when running the publish-schema workflow.

Ref: https://issues.redhat.com/browse/EC-1238