### PR TITLE
Format imageUrl to accept multiple sub-paths

### DIFF
--- a/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -177,7 +177,7 @@ spec:
                                   type: string
                                 imageUrl:
                                   description: ImageUrl is used to specify an image by its URL without a tag.
-                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$
+                                  pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
                                   type: string
                                 value:
                                   type: string
@@ -210,7 +210,7 @@ spec:
                                   type: string
                                 imageUrl:
                                   description: ImageUrl is used to specify an image by its URL without a tag.
-                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$
+                                  pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
                                   type: string
                                 value:
                                   type: string

--- a/api/v1alpha1/enterprisecontractpolicy_types.go
+++ b/api/v1alpha1/enterprisecontractpolicy_types.go
@@ -113,7 +113,7 @@ type VolatileCriteria struct {
 
 	// ImageUrl is used to specify an image by its URL without a tag.
 	// +optional
-	// +kubebuilder:validation:Pattern=`^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$`
+	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$`
 	ImageUrl string `json:"imageUrl,omitempty"`
 }
 

--- a/api/v1alpha1/policy_spec.json
+++ b/api/v1alpha1/policy_spec.json
@@ -178,7 +178,7 @@
         },
         "imageUrl": {
           "type": "string",
-          "description": "ImageUrl is used to specify an image by its URL without a tag.\n+optional\n+kubebuilder:validation:Pattern=`^(?:https:\\/\\/)?[a-z0-9.-]+\\/[a-z0-9-]+\\/[a-z0-9-]+$`"
+          "description": "ImageUrl is used to specify an image by its URL without a tag.\n+optional\n+kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$`"
         }
       },
       "additionalProperties": false,

--- a/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -177,7 +177,7 @@ spec:
                                   type: string
                                 imageUrl:
                                   description: ImageUrl is used to specify an image by its URL without a tag.
-                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$
+                                  pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
                                   type: string
                                 value:
                                   type: string
@@ -210,7 +210,7 @@ spec:
                                   type: string
                                 imageUrl:
                                   description: ImageUrl is used to specify an image by its URL without a tag.
-                                  pattern: ^(?:https:\/\/)?[a-z0-9.-]+\/[a-z0-9-]+\/[a-z0-9-]+$
+                                  pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
                                   type: string
                                 value:
                                   type: string


### PR DESCRIPTION
Repo urls can have multiple orgs. This new regex
supports this and also drops support for https.
The component URL does not contain the https in
ec-cli, so this simplifies things.

https://issues.redhat.com/browse/EC-1258