### PR TITLE
Add "reference" field to volatileConfig

### DIFF
--- a/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/api/config/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -179,6 +179,9 @@ spec:
                                   description: ImageUrl is used to specify an image by its URL without a tag.
                                   pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
                                   type: string
+                                reference:
+                                  description: Reference is used to include a link to related information such as a Jira issue URL.
+                                  type: string
                                 value:
                                   type: string
                               required:
@@ -211,6 +214,9 @@ spec:
                                 imageUrl:
                                   description: ImageUrl is used to specify an image by its URL without a tag.
                                   pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
+                                  type: string
+                                reference:
+                                  description: Reference is used to include a link to related information such as a Jira issue URL.
                                   type: string
                                 value:
                                   type: string

--- a/api/v1alpha1/enterprisecontractpolicy_types.go
+++ b/api/v1alpha1/enterprisecontractpolicy_types.go
@@ -115,6 +115,10 @@ type VolatileCriteria struct {
 	// +optional
 	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$`
 	ImageUrl string `json:"imageUrl,omitempty"`
+
+	// Reference is used to include a link to related information such as a Jira issue URL.
+	// +optional
+	Reference string `json:"reference,omitempty"`
 }
 
 // VolatileSourceConfig specifies volatile configuration for a policy source.

--- a/api/v1alpha1/policy_spec.json
+++ b/api/v1alpha1/policy_spec.json
@@ -179,6 +179,10 @@
         "imageUrl": {
           "type": "string",
           "description": "ImageUrl is used to specify an image by its URL without a tag.\n+optional\n+kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$`"
+        },
+        "reference": {
+          "type": "string",
+          "description": "Reference is used to include a link to related information such as a Jira issue URL.\n+optional"
         }
       },
       "additionalProperties": false,

--- a/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
+++ b/config/crd/bases/appstudio.redhat.com_enterprisecontractpolicies.yaml
@@ -179,6 +179,9 @@ spec:
                                   description: ImageUrl is used to specify an image by its URL without a tag.
                                   pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
                                   type: string
+                                reference:
+                                  description: Reference is used to include a link to related information such as a Jira issue URL.
+                                  type: string
                                 value:
                                   type: string
                               required:
@@ -211,6 +214,9 @@ spec:
                                 imageUrl:
                                   description: ImageUrl is used to specify an image by its URL without a tag.
                                   pattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9](?:\/[a-z0-9][a-z0-9-]*[a-z0-9]){2,}$
+                                  type: string
+                                reference:
+                                  description: Reference is used to include a link to related information such as a Jira issue URL.
                                   type: string
                                 value:
                                   type: string

--- a/docs/modules/ROOT/pages/reference.adoc
+++ b/docs/modules/ROOT/pages/reference.adoc
@@ -205,6 +205,7 @@ Appears In: xref:{anchor_prefix}-github-com-enterprise-contract-enterprise-contr
 ImageRef is used to specify an image by its digest. +
 | *`imageDigest`* __string__ | ImageDigest is used to specify an image by its digest. +
 | *`imageUrl`* __string__ | ImageUrl is used to specify an image by its URL without a tag. +
+| *`reference`* __string__ | Reference is used to include a link to related information such as a Jira issue URL. +
 |===
 
 


### PR DESCRIPTION
In the volatileConfig list item (part of the ECP), we add another field called "reference". It is optional and does nothing, but it is a place to add a Jira link to the issue tracker for the reason why the exception is needed.

This API change will not affect current clients since the new field is not required.

Ref: https://issues.redhat.com/browse/EC-1246