### PR TITLE
Add CI check for uncommitted changes by "make all"

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Check go versions
         uses: enterprise-contract/github-workflows/golang-version-check@main
 
+      - name: Build all
+        run: make all
+
       - name: Test
         run: make test
 
@@ -69,6 +72,7 @@ jobs:
           if ! git diff --exit-code -s; then
             for f in $(git diff --exit-code --name-only); do
               echo "::error file=$f,line=1,col=1,endColumn=1::File was modified in build"
+              echo -e "\033[1;33mHint:\033[0m Maybe you need to run \033[1;32mmake all\033[0m"
             done
             exit 1
           fi


### PR DESCRIPTION
This check fails pre-merge if there are uncommitted changes generated during `make all` execution.

Refs: https://issues.redhat.com/browse/EC-1262