### PR TITLE
TEST - uncommitted changes by `make all` should fail CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -72,3 +72,24 @@ jobs:
             done
             exit 1
           fi
+
+  Check-Uncommitted-Make-All:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run "make all"
+        run: make all
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code -s; then
+            for f in $(git diff --exit-code --name-only); do
+              echo "::error file=$f,line=1,col=1,endColumn=1::File was modified in build"
+            done
+            exit 1
+          fi
+

--- a/docs/modules/ROOT/pages/reference.adoc
+++ b/docs/modules/ROOT/pages/reference.adoc
@@ -201,11 +201,7 @@ Appears In: xref:{anchor_prefix}-github-com-enterprise-contract-enterprise-contr
 | *`value`* __string__ | 
 | *`effectiveOn`* __string__ | 
 | *`effectiveUntil`* __string__ | 
-| *`imageRef`* __string__ | DEPRECATED: Use ImageDigest instead +
-ImageRef is used to specify an image by its digest. +
-| *`imageDigest`* __string__ | ImageDigest is used to specify an image by its digest. +
-| *`imageUrl`* __string__ | ImageUrl is used to specify an image by its URL without a tag. +
-| *`reference`* __string__ | Reference is used to include a link to related information such as a Jira issue URL. +
+| *`imageRef`* __string__ | ImageRef is used to specify an image by its digest. +
 |===
 
 


### PR DESCRIPTION
This PR is to validate https://github.com/enterprise-contract/enterprise-contract-controller/pull/525 - a new CI check for uncommitted changes generated by `make all`.

Running `make all` from this PR should generate uncommitted files. This is intentional, to see if the new CI test will catch that and fail.

### DO NOT MERGE!