### PR TITLE
chore: update references to `ec-policies` repo

### DIFF
--- a/config/crd/openshift_console_example.yaml
+++ b/config/crd/openshift_console_example.yaml
@@ -24,7 +24,7 @@ spec:
       sources:
         - name: Default EC Policies
           data:
-            - git::https://github.com/enterprise-contract/ec-policies//example/data
+            - git::https://github.com/conforma/policy//example/data
           policy:
             - oci::quay.io/hacbs-contract/ec-release-policy:latest
           ruleData:


### PR DESCRIPTION
This commit updates references to the policy repository from `enterprise-contract/ec-policies` to `conforma/policy`.

Ref: EC-1113