### PR TITLE
chore: update references to github-workflows repo

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -22,7 +22,7 @@ name: 'Auto merge'
 
 jobs:
   auto-merge:
-    uses: enterprise-contract/github-workflows/.github/workflows/auto-merge.yaml@main
+    uses: conforma/github-workflows/.github/workflows/auto-merge.yaml@main
     secrets: inherit
     permissions:
       pull-requests: write

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,7 +33,7 @@ jobs:
           cache-dependency-path: '**/go.sum'
 
       - name: Check go versions
-        uses: enterprise-contract/github-workflows/golang-version-check@main
+        uses: conforma/github-workflows/golang-version-check@main
 
       - name: Build all
         run: make all


### PR DESCRIPTION
This commit updates references to the github-workflow from `enterprise-contract/github-workflow` to `conforma/github-workflow`.

Ref: EC-1118