### PR TITLE
Add PR size labeling workflow

### DIFF
--- a/.github/workflows/label-pr-size.yaml
+++ b/.github/workflows/label-pr-size.yaml
@@ -1,0 +1,32 @@
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: PR Size Label
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR by size
+        uses: conforma/pr-size-label-action@v1.0.0


### PR DESCRIPTION
This PR adds an automated workflow that labels pull requests based on their size (additions + deletions). The workflow will run on PR creation and updates, ensuring only one size label is present at any time. Resolves: EC-1485